### PR TITLE
Added an integration test for plugin Installation 

### DIFF
--- a/.github/workflows/test-plugin-installation.yml
+++ b/.github/workflows/test-plugin-installation.yml
@@ -1,9 +1,9 @@
 name: Test installation of plugin against the PR
 on:
   push:
-    branches: [ master ]
+    branches: [ main ]
   pull_request:
-    branches: [ master ]
+    branches: [ main ]
 
 jobs:
   test-plugin-installation:

--- a/.github/workflows/test-plugin-installation.yml
+++ b/.github/workflows/test-plugin-installation.yml
@@ -1,0 +1,20 @@
+name: Test installation of plugin against the PR
+on:
+  push:
+    branches: [ master ]
+  pull_request:
+    branches: [ master ]
+
+jobs:
+  test-plugin-installation:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Install Kurtosis
+        run: |
+          echo "deb [trusted=yes] https://apt.fury.io/kurtosis-tech/ /" | sudo tee /etc/apt/sources.list.d/kurtosis.list
+          sudo apt update
+          sudo apt install kurtosis-cli
+      - name: Install plugins
+        run: |
+          set -euo pipefail
+          kurtosis run github.com/kurtosis-tech/autogpt-package '{"OPENAI_API_KEY": "test", "ALLOWLISTED_PLUGINS": "AutoGPTPMPlugin", "__plugin_branch_to_use": '\"${{ github.head_ref}}\"', "__plugin_repo_to_use":'\"${{ github.event.pull_request.head.repo.full_name }}\"'}'


### PR DESCRIPTION
Hey! Great job with the plugin!

I have recently added integration tests to the standard repository that ensure that the plugins install as expected. I have created a PR for your repository with the similar integration test. As I am not an admin here I can't trigger the workflow but it works like - https://github.com/h4ck3rk3y/Auto-GPT-Crypto-Plugin/actions/runs/4959559330/jobs/8873833979?pr=1

if you(author) create a PR or someone else creates a PR it will try running that branch against Auto-GPT to ensure that the plugin works as expected

Disclaimer - I am working on a tool called Kurtosis! The same tool that is used in the ci.yml I added. With Kurtosis running AutoGPT is as simple as -

kurtosis run github.com/kurtosis-tech/autogpt-package --enclave autogpt '{"OPENAI_API_KEY": "YOUR_API_KEY_HERE", "ALLOWLISTED_PLUGINS": "AutoGPTPMPlugin"}'
kurtosis service shell autogpt autogpt --exec "python -m autogpt"
Kurtosis takes care of downloading the plugin for you & setting up the backend (you could have passed in"MEMORY_BACKEND": "weaviate" and we would have spun it up for you)

Here is our [AutoGPT-Package](https://github.com/kurtosis-tech/autogpt-package)

Adding support for a new plugin to Kurtosis is as simple as adding a line [here](https://github.com/kurtosis-tech/autogpt-package/blob/main/plugins.star#L21)